### PR TITLE
Add .vscode to the gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Local reference configuration
 Directory.Build.targets
 
+# Local preferences
+.vscode/
+
 # Packaging directories
 [Bb]uild/
 [Dd]ist/


### PR DESCRIPTION
`.editorconfig` should be used for shared IDE configuration. `.vscode` can be used for local preferences and overrides, thus changes to it should be ignored.