### PR TITLE
Pass the executing assembly to Harmony.PatchAll

### DIFF
--- a/MOD_NAME/Main.cs
+++ b/MOD_NAME/Main.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Reflection;
 using HarmonyLib;
 using UnityModManagerNet;
 
@@ -14,7 +15,7 @@ public static class Main
 		try
 		{
 			harmony = new Harmony(modEntry.Info.Id);
-			harmony.PatchAll();
+			harmony.PatchAll(Assembly.GetExecutingAssembly());
 
 			// Other plugin startup logic
 		}


### PR DESCRIPTION
This fixes the issue of methods not being patched using the code provided by the template.