### PR TITLE
Target only patches from self for unpatching

### DIFF
--- a/MOD_NAME/Main.cs
+++ b/MOD_NAME/Main.cs
@@ -21,7 +21,7 @@ public static class Main
 		catch (Exception ex)
 		{
 			modEntry.Logger.LogException($"Failed to load {modEntry.Info.DisplayName}:", ex);
-			harmony?.UnpatchAll();
+			harmony?.UnpatchAll(modEntry.Info.Id);
 			return false;
 		}
 


### PR DESCRIPTION
From [Harmony docs](https://harmony.pardeike.net/articles/basics.html#unpatching):
```csharp
// every patch on every method ever patched (including others patches):
var harmony = new Harmony("my.harmony.id");
harmony.UnpatchAll();
```

We can avoid this by passing the id we used to create the Harmony instance to UnpatchAll:
```csharp
// only the patches that one specific Harmony instance did:
harmony.UnpatchAll("my.harmony.id");
```