### PR TITLE
Direct UMM to raw repository.json file

### DIFF
--- a/info.json
+++ b/info.json
@@ -5,5 +5,5 @@
 	"Author": "MOD_AUTHOR",
 	"EntryMethod": "MOD_NAME.Main.Load",
 	"ManagerVersion": "0.27.3",
-	"Repository": "https://github.com/OWNER/REPOSITORY/blob/main/repository.json"
+	"Repository": "https://raw.githubusercontent.com/OWNER/REPOSITORY/blob/main/repository.json"
 }


### PR DESCRIPTION
URLs targeting github.com are responded to with a HTML webpage. UMM expects JSON, not HTML.
A raw.githubusercontent.com URL is required to access the raw JSON file.