### PR TITLE
fix the repository link in info.json

### DIFF
--- a/info.json
+++ b/info.json
@@ -5,5 +5,5 @@
 	"Author": "MOD_AUTHOR",
 	"EntryMethod": "MOD_NAME.Main.Load",
 	"ManagerVersion": "0.27.3",
-	"Repository": "https://raw.githubusercontent.com/OWNER/REPOSITORY/blob/main/repository.json"
+	"Repository": "https://raw.githubusercontent.com/OWNER/REPOSITORY/main/repository.json"
 }


### PR DESCRIPTION
removes leftover `/blob` from #9 which isn't necessary for url's to raw files